### PR TITLE
Fix method return capture in the presence of ret branches

### DIFF
--- a/clrie/include/clrie/instruction_graph.h
+++ b/clrie/include/clrie/instruction_graph.h
@@ -59,7 +59,24 @@ namespace clrie {
 
         // Insert an instruction before another instruction AND update jmp targets and exception ranges that used
         // to point to the old instruction to point to the new instruction.
-        void insert_before_and_retarget_offsets(com::ptr<IInstruction> instruction_orig, com::ptr<IInstruction> instruction_new);
+        void insert_before_and_retarget_offsets(com::ptr<IInstruction> instruction_orig, com::ptr<IInstruction> instruction_new)
+        {
+            com::hresult::check(ptr_->InsertBeforeAndRetargetOffsets(instruction_orig, instruction_new));
+        }
+
+        template <typename Container>
+        void insert_before_and_retarget_offsets(com::ptr<IInstruction> pos, const Container &&instructions)
+        {
+            bool retargeted = false;
+            for (auto ins : instructions) {
+                if (retargeted)
+                    insert_before(pos, ins);
+                else {
+                    insert_before_and_retarget_offsets(pos, ins);
+                    retargeted = true;
+                }
+            }
+        }
 
         // Replace an instruction with another instruction. The old instruction continues to live in the original graph but is marked replaced
         void replace(com::ptr<IInstruction> instruction_orig, com::ptr<IInstruction> *p_instruction_new);

--- a/smoketest/expected.appmap.json
+++ b/smoketest/expected.appmap.json
@@ -5,7 +5,17 @@
         {
           "children": [
             {
+              "name": "Test2",
+              "static": true,
+              "type": "function"
+            },
+            {
               "name": "Main",
+              "static": true,
+              "type": "function"
+            },
+            {
+              "name": "Test",
               "static": true,
               "type": "function"
             }
@@ -27,8 +37,32 @@
       "static": true
     },
     {
-      "event": "return",
+      "defined_class": "hello.Program",
+      "event": "call",
       "id": 2,
+      "method_id": "Test",
+      "static": true
+    },
+    {
+      "event": "return",
+      "id": 3,
+      "parent_id": 2
+    },
+    {
+      "defined_class": "hello.Program",
+      "event": "call",
+      "id": 4,
+      "method_id": "Test2",
+      "static": true
+    },
+    {
+      "event": "return",
+      "id": 5,
+      "parent_id": 4
+    },
+    {
+      "event": "return",
+      "id": 6,
       "parent_id": 1
     }
   ]

--- a/smoketest/hello/Program.cs
+++ b/smoketest/hello/Program.cs
@@ -4,8 +4,20 @@ namespace hello
 {
     class Program
     {
+        static void Test(string? text) {
+            if (text == null) {
+                Console.WriteLine("null test");
+            }
+        }
+
+        static void Test2() {
+            Console.WriteLine("test2");
+        }
+
         static void Main(string[] args)
         {
+            Test("text");
+            Test2();
             Console.WriteLine("Hello World!");
         }
     }

--- a/source/generation.cpp
+++ b/source/generation.cpp
@@ -91,12 +91,12 @@ namespace appmap {
             } else if (ev.kind == event_kind::ret) {
                 if (stack.empty()) {
                     // known bug
-                    spdlog::debug("stack empty on return, ignoring");
+                    spdlog::warn("stack empty on return, ignoring");
                     continue;
                 }
                 if (stack.back().fid != ev.function) {
                     // known bug
-                    spdlog::debug("function mismatch detected on return; function: {}, stack: {}", ev.function, stack | ranges::views::transform([](auto &ev){ return ev.fid; }));
+                    spdlog::warn("function mismatch detected on return; function: {}, stack: {}", method_infos.at(ev.function).method_id, stack | ranges::views::transform([](auto &ev){ return method_infos.at(ev.fid).method_id; }));
                     if (ranges::any_of(stack, [fid = ev.function](const auto &ev) { return ev.fid == fid; })) {
                         // try to do out best by generating the missing returns
                         while (stack.back().fid != ev.function) {


### PR DESCRIPTION
In some methods returns weren't captured correctly. This happened
when there was a branch straight to the return; it kept pointing
at the return after instrumentation.

This change fixes this, and also turns on single return
instrumentation (I haven't seen any issues with it with this change,
fingers crosses); error messages that would have been commonly
caused by this problem were changed to warn level.

Fixes #20 (partly; enough to always warn of a problem). Fixes #11 (tentatively; I haven't seen this issue anymore).