### PR TITLE
Capture return values

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -26,14 +26,14 @@ jobs:
       - name: configure
         run: cmake -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo
         env:
-          CC: gcc-8
-          CXX: g++-8
+          CC: gcc-9
+          CXX: g++-9
 
       - name: build
         run: cmake --build build -j4
         env:
-          CC: gcc-8
-          CXX: g++-8
+          CC: gcc-9
+          CXX: g++-9
 
       - name: test
         run: build/test/appmap-test

--- a/clrie/include/clrie/instruction_factory.h
+++ b/clrie/include/clrie/instruction_factory.h
@@ -11,31 +11,45 @@ namespace clrie {
         instruction_factory(com::ptr<IInstructionFactory> &&factory) noexcept : ptr(std::move(factory)) {}
 
         using instruction = com::ptr<IInstruction>;
-        using instruction_sequence = std::vector<instruction>;
+        struct instruction_sequence : std::vector<instruction>
+        {
+            using std::vector<instruction>::vector;
+
+            instruction_sequence &operator+=(const instruction &i) {
+                push_back(i);
+                return *this;
+            }
+
+            instruction_sequence &operator+=(const instruction_sequence &is) {
+                for (auto &i: is)
+                    push_back(i);
+                return *this;
+            }
+        };
 
         // Create an instance of an instruction that takes no operands
-        com::ptr<IInstruction> create_instruction(enum ILOrdinalOpcode opcode) {
+        com::ptr<IInstruction> create_instruction(enum ILOrdinalOpcode opcode) const {
             com::ptr<IInstruction> result;
             com::hresult::check(ptr->CreateInstruction(opcode, &result));
             return result;
         }
 
         // Create an instance of an instruction that takes a byte operand
-        com::ptr<IInstruction> create_byte_operand_instruction(enum ILOrdinalOpcode opcode, BYTE operand) {
+        com::ptr<IInstruction> create_byte_operand_instruction(enum ILOrdinalOpcode opcode, BYTE operand) const {
             com::ptr<IInstruction> result;
             com::hresult::check(ptr->CreateByteOperandInstruction(opcode, operand, &result));
             return result;
         }
 
         // Create an instance of an instruction that takes a USHORT operand
-        com::ptr<IInstruction> create_u_short_operand_instruction(enum ILOrdinalOpcode opcode, USHORT operand) {
+        com::ptr<IInstruction> create_u_short_operand_instruction(enum ILOrdinalOpcode opcode, USHORT operand) const {
             com::ptr<IInstruction> result;
             com::hresult::check(ptr->CreateUShortOperandInstruction(opcode, operand, &result));
             return result;
         }
 
         // Create an instance of an instruction that takes a ULONG operand
-        com::ptr<IInstruction> create_int_operand_instruction(enum ILOrdinalOpcode opcode, INT32 operand) {
+        com::ptr<IInstruction> create_int_operand_instruction(enum ILOrdinalOpcode opcode, INT32 operand) const {
             com::ptr<IInstruction> result;
             com::hresult::check(ptr->CreateIntOperandInstruction(opcode, operand, &result));
             return result;
@@ -43,14 +57,14 @@ namespace clrie {
 
         // Create an instance of an instruction that takes a 64 bit operand. The name "Long" in this case comes from the msil definition
         // of a 64 bit value
-        com::ptr<IInstruction> create_long_operand_instruction(enum ILOrdinalOpcode opcode, INT64 operand) {
+        com::ptr<IInstruction> create_long_operand_instruction(enum ILOrdinalOpcode opcode, INT64 operand) const {
             com::ptr<IInstruction> result;
             com::hresult::check(ptr->CreateLongOperandInstruction(opcode, operand, &result));
             return result;
         }
 
         template <typename T>
-        instruction load_constant(T value) {
+        instruction load_constant(T value) const {
             IInstruction *result;
             if constexpr (sizeof(T) == sizeof(uint64_t)) {
                 com::hresult::check(ptr->CreateLongOperandInstruction(Cee_Ldc_I8, reinterpret_cast<uint64_t>(value), &result));
@@ -65,40 +79,40 @@ namespace clrie {
         }
 
         template <typename... Args>
-        instruction_sequence load_constants(Args... args) {
+        instruction_sequence load_constants(Args... args) const {
             return { load_constant(args)... };
         }
 
         // Create an instance of an instruction that takes a float operand
-        com::ptr<IInstruction> create_float_operand_instruction(enum ILOrdinalOpcode opcode, float operand) {
+        com::ptr<IInstruction> create_float_operand_instruction(enum ILOrdinalOpcode opcode, float operand) const {
             com::ptr<IInstruction> result;
             com::hresult::check(ptr->CreateFloatOperandInstruction(opcode, operand, &result));
             return result;
         }
 
         // Create an instance of an instruction that takes a double operand
-        com::ptr<IInstruction> create_double_operand_instruction(enum ILOrdinalOpcode opcode, double operand) {
+        com::ptr<IInstruction> create_double_operand_instruction(enum ILOrdinalOpcode opcode, double operand) const {
             com::ptr<IInstruction> result;
             com::hresult::check(ptr->CreateDoubleOperandInstruction(opcode, operand, &result));
             return result;
         }
 
         // Create an instance of an instruction that takes a metadata token operand
-        com::ptr<IInstruction> create_token_operand_instruction(enum ILOrdinalOpcode opcode, mdToken operand) {
+        com::ptr<IInstruction> create_token_operand_instruction(enum ILOrdinalOpcode opcode, mdToken operand) const {
             com::ptr<IInstruction> result;
             com::hresult::check(ptr->CreateTokenOperandInstruction(opcode, operand, &result));
             return result;
         }
 
         // Create a branch instruction
-        com::ptr<IInstruction> create_branch_instruction(enum ILOrdinalOpcode opcode, com::ptr<IInstruction> branch_target) {
+        com::ptr<IInstruction> create_branch_instruction(enum ILOrdinalOpcode opcode, com::ptr<IInstruction> branch_target) const {
             com::ptr<IInstruction> result;
             com::hresult::check(ptr->CreateBranchInstruction(opcode, branch_target, &result));
             return result;
         }
 
         // Create a switch instruction
-        com::ptr<IInstruction> create_switch_instruction(enum ILOrdinalOpcode opcode, const std::vector<IInstruction *> &targets) {
+        com::ptr<IInstruction> create_switch_instruction(enum ILOrdinalOpcode opcode, const std::vector<IInstruction *> &targets) const {
             com::ptr<IInstruction> result;
             com::hresult::check(ptr->CreateSwitchInstruction(opcode, targets.size(), const_cast<IInstruction **>(targets.data()), &result));
             return result;
@@ -108,28 +122,28 @@ namespace clrie {
         // Helpers that adjust the opcode to match the operand size
 
         // Creates an operand instruction of type Cee_Ldc_I4, or Cee_Ldc_I4_S, Cee_Ldc_I4_0, Cee_Ldc_I4_1, Cee_Ldc_I4_2...
-        com::ptr<IInstruction> create_load_const_instruction(int value) {
+        com::ptr<IInstruction> create_load_const_instruction(int value) const {
             IInstruction *result;
             com::hresult::check(ptr->CreateLoadConstInstruction(value, &result));
             return result;
         }
 
         // Creates an operand instruction of type Cee_Ldloc, or (Cee_Ldloc_S, (Cee_Ldloc_0, Cee_Ldloc_1, Cee_Ldloc_1...
-        com::ptr<IInstruction> create_load_local_instruction(USHORT index) {
+        com::ptr<IInstruction> create_load_local_instruction(USHORT index) const {
             com::ptr<IInstruction> result;
             com::hresult::check(ptr->CreateLoadLocalInstruction(index, &result));
             return result;
         }
 
         // Creates an operand instruction of type Cee_Ldloca, or Cee_Ldloca_S
-        com::ptr<IInstruction> create_load_local_address_instruction(USHORT index) {
+        com::ptr<IInstruction> create_load_local_address_instruction(USHORT index) const {
             com::ptr<IInstruction> result;
             com::hresult::check(ptr->CreateLoadLocalAddressInstruction(index, &result));
             return result;
         }
 
         // Creates an operand instruction of type Cee_Stloc, or Cee_Stloc_S, Cee_Stloc_0, Cee_Stloc_1, Cee_Stloc_2...
-        com::ptr<IInstruction> create_store_local_instruction(USHORT index) {
+        com::ptr<IInstruction> create_store_local_instruction(USHORT index) const {
             com::ptr<IInstruction> result;
             com::hresult::check(ptr->CreateStoreLocalInstruction(index, &result));
             return result;
@@ -143,7 +157,7 @@ namespace clrie {
         }
 
         // Creates an operand instruction of type Cee_Ldarga or Cee_Ldarga_S
-        com::ptr<IInstruction> create_load_arg_address_instruction(USHORT index) {
+        com::ptr<IInstruction> create_load_arg_address_instruction(USHORT index) const {
             com::ptr<IInstruction> result;
             com::hresult::check(ptr->CreateLoadArgAddressInstruction(index, &result));
             return result;
@@ -156,7 +170,7 @@ namespace clrie {
         //    next and original previous fields set.
         //
         // 2) This graph will not have a method info set and cannot create exception sections or handlers.
-        com::ptr<IInstructionGraph> decode_instruction_byte_stream(const std::vector<uint8_t> &stream) {
+        com::ptr<IInstructionGraph> decode_instruction_byte_stream(const std::vector<uint8_t> &stream) const {
             com::ptr<IInstructionGraph> result;
             com::hresult::check(ptr->DecodeInstructionByteStream(stream.size(), stream.data(), &result));
             return result;

--- a/clrie/include/clrie/instruction_graph.h
+++ b/clrie/include/clrie/instruction_graph.h
@@ -47,7 +47,7 @@ namespace clrie {
         }
 
         template <typename Container>
-        void insert_before(com::ptr<IInstruction> pos, const Container &&instructions)
+        void insert_before(com::ptr<IInstruction> pos, const Container &instructions)
         {
             for (auto ins : instructions)
                 insert_before(pos, ins);
@@ -65,7 +65,7 @@ namespace clrie {
         }
 
         template <typename Container>
-        void insert_before_and_retarget_offsets(com::ptr<IInstruction> pos, const Container &&instructions)
+        void insert_before_and_retarget_offsets(com::ptr<IInstruction> pos, const Container &instructions)
         {
             bool retargeted = false;
             for (auto ins : instructions) {

--- a/clrie/include/clrie/method_info.h
+++ b/clrie/include/clrie/method_info.h
@@ -9,12 +9,6 @@
 #include "clrie/module_info.h"
 #undef __valid // microsoft can't into C++ -- __ names are reserved
 
-template<>
-constexpr GUID com::guid_of<IMetaDataEmit>() noexcept {
-    using namespace com::literals;
-    return "{BA3FEE4C-ECB9-4e41-83B7-183FA41CD859}"_guid;
-}
-
 namespace clrie {
     struct method_info : public com::ptr<IMethodInfo> {
         method_info(IMethodInfo *info = nullptr) noexcept : com::ptr<IMethodInfo>(info) {}

--- a/clrie/include/clrie/module_info.h
+++ b/clrie/include/clrie/module_info.h
@@ -4,6 +4,24 @@
 #include "com/ptr.h"
 #include <cor.h>
 
+template<>
+constexpr GUID com::guid_of<IMetaDataEmit>() noexcept {
+    using namespace com::literals;
+    return "{BA3FEE4C-ECB9-4e41-83B7-183FA41CD859}"_guid;
+}
+
+template<>
+constexpr GUID com::guid_of<IMetaDataImport>() noexcept {
+    using namespace com::literals;
+    return "{7DAC8207-D3AE-4c75-9B67-92801A497D44}"_guid;
+}
+
+template<>
+constexpr GUID com::guid_of<IMetaDataAssemblyImport>() noexcept {
+    using namespace com::literals;
+    return "{EE62470B-E94B-424e-9B7C-2F00C9249F93}"_guid;
+}
+
 namespace clrie {
     struct module_info : public com::ptr<IModuleInfo>
     {
@@ -26,17 +44,17 @@ namespace clrie {
             return get(&interface_type::GetAppDomainInfo);
         }
 
-        com::ptr<IUnknown> meta_data_import() {
-            return get(&interface_type::GetMetaDataImport);
+        com::ptr<IMetaDataImport> meta_data_import() {
+            return get(&interface_type::GetMetaDataImport).as<IMetaDataImport>();
         }
-        com::ptr<IUnknown> meta_data_assembly_import() {
-            return get(&interface_type::GetMetaDataAssemblyImport);
+        com::ptr<IMetaDataAssemblyImport> meta_data_assembly_import() {
+            return get(&interface_type::GetMetaDataAssemblyImport).as<IMetaDataAssemblyImport>();
         }
 
         // NOTE: It is expected that these fail for winmd files which do not support
         // metadata emit.
-        com::ptr<IUnknown> meta_data_emit() {
-            return get(&interface_type::GetMetaDataEmit);
+        com::ptr<IMetaDataEmit> meta_data_emit() {
+            return get(&interface_type::GetMetaDataEmit).as<IMetaDataEmit>();
         }
         com::ptr<IUnknown> meta_data_assembly_emit() {
             return get(&interface_type::GetMetaDataAssemblyEmit);

--- a/smoketest/expected.appmap.json
+++ b/smoketest/expected.appmap.json
@@ -48,8 +48,8 @@
       "id": 3,
       "parent_id": 2,
       "return_value": {
-        "class": "I4",
-        "value": 1
+        "class": "STRING",
+        "value": "Bar"
       }
     },
     {

--- a/smoketest/expected.appmap.json
+++ b/smoketest/expected.appmap.json
@@ -46,7 +46,11 @@
     {
       "event": "return",
       "id": 3,
-      "parent_id": 2
+      "parent_id": 2,
+      "return_value": {
+        "class": "I4",
+        "value": 1
+      }
     },
     {
       "defined_class": "hello.Program",

--- a/smoketest/hello/Program.cs
+++ b/smoketest/hello/Program.cs
@@ -4,16 +4,17 @@ namespace hello
 {
     class Program
     {
-        static int Test(string? text) {
+        static string Test(string? text) {
             if (text == null) {
                 Console.WriteLine("null test");
-                return 0;
+                return "Foo";
             }
-            return 1;
+            return "Bar";
         }
 
         static void Test2() {
             Console.WriteLine("test2");
+            Console.WriteLine("test2".ToString());
         }
 
         static void Main(string[] args)

--- a/smoketest/hello/Program.cs
+++ b/smoketest/hello/Program.cs
@@ -4,10 +4,12 @@ namespace hello
 {
     class Program
     {
-        static void Test(string? text) {
+        static int Test(string? text) {
             if (text == null) {
                 Console.WriteLine("null test");
+                return 0;
             }
+            return 1;
         }
 
         static void Test2() {
@@ -16,7 +18,7 @@ namespace hello
 
         static void Main(string[] args)
         {
-            Test("text");
+            Console.WriteLine(Test("text"));
             Test2();
             Console.WriteLine("Hello World!");
         }

--- a/source/event.h
+++ b/source/event.h
@@ -1,13 +1,19 @@
 #pragma once
+#include <optional>
+#include <variant>
 
 #include <corprof.h>
 
 namespace appmap {
+    using cor_value = std::variant<uint64_t, int64_t, bool>;
+
     enum class event_kind {
         call, ret
     };
+
     struct event {
         event_kind kind;
         FunctionID function;
+        std::optional<cor_value> return_value = std::nullopt;
     };
 }

--- a/source/event.h
+++ b/source/event.h
@@ -1,11 +1,12 @@
 #pragma once
 #include <optional>
+#include <string>
 #include <variant>
 
 #include <corprof.h>
 
 namespace appmap {
-    using cor_value = std::variant<uint64_t, int64_t, bool>;
+    using cor_value = std::variant<std::string, uint64_t, int64_t, bool>;
 
     enum class event_kind {
         call, ret

--- a/source/instrumentation.cpp
+++ b/source/instrumentation.cpp
@@ -1,5 +1,6 @@
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/bundled/ranges.h>
+#include <utf8.h>
 #include "instrumentation.h"
 
 using namespace appmap;
@@ -12,4 +13,41 @@ appmap::instrumentation::instruction_sequence appmap::instrumentation::make_call
         create_long_operand_instruction(Cee_Ldc_I8, reinterpret_cast<int64_t>(fn)),
         create_token_operand_instruction(Cee_Calli, token)
     };
+}
+
+namespace {
+    mdAssemblyRef find_assembly_ref(com::ptr<IMetaDataAssemblyImport> import, std::u16string name)
+    {
+        HCORENUM corenum = nullptr;
+        std::vector<mdAssemblyRef> assemblies(50);
+        ULONG count;
+        com::hresult::check(import->EnumAssemblyRefs(&corenum, assemblies.data(), assemblies.size(), &count));
+        import->CloseEnum(corenum);
+        assert(count < assemblies.size());
+        assemblies.resize(count);
+
+        for (auto assembly: assemblies) {
+            char16_t assembly_name[50];
+            com::hresult::check(import->GetAssemblyRefProps(assembly, nullptr, nullptr, assembly_name, 50, &count, nullptr, nullptr, nullptr, nullptr));
+            assert(count < 50);
+            if (name == assembly_name)
+                return assembly;
+        }
+
+        return mdAssemblyRefNil;
+    }
+}
+
+clrie::instruction_factory::instruction appmap::instrumentation::create_call_to_string() const
+{
+    static std::unordered_map<ModuleID, mdMemberRef> object_to_string_refs;
+
+    if (object_to_string_refs.find(module_id) == object_to_string_refs.end()) {
+        auto system_runtime = find_assembly_ref(module.meta_data_assembly_import(), u"System.Runtime");
+        auto import = module.meta_data_import();
+        auto system_object = import.get<mdTypeRef>(&IMetaDataImport::FindTypeRef, system_runtime, u"System.Object");
+        object_to_string_refs[module_id] = import.get<mdMemberRef>(&IMetaDataImport::FindMemberRef, system_object, u"ToString", nullptr, 0);
+    }
+
+    return create_token_operand_instruction(Cee_Callvirt, object_to_string_refs[module_id]);
 }

--- a/source/instrumentation.cpp
+++ b/source/instrumentation.cpp
@@ -9,7 +9,7 @@ appmap::instrumentation::instruction_sequence appmap::instrumentation::make_call
     mdToken token;
     com::hresult::check(metadata->GetTokenFromSig(signature.data(), signature.size(), &token));
     return {
-        factory.create_long_operand_instruction(Cee_Ldc_I8, reinterpret_cast<int64_t>(fn)),
-        factory.create_token_operand_instruction(Cee_Calli, token)
+        create_long_operand_instruction(Cee_Ldc_I8, reinterpret_cast<int64_t>(fn)),
+        create_token_operand_instruction(Cee_Calli, token)
     };
 }

--- a/source/instrumentation.h
+++ b/source/instrumentation.h
@@ -75,16 +75,22 @@ namespace appmap {
         instrumentation(clrie::method_info method_info) :
             clrie::instruction_factory(method_info.instruction_factory()),
             method(method_info),
-            metadata(method.module_info().meta_data_emit().as<IMetaDataEmit>())
+            module(method.module_info()),
+            module_id(module.module_id()),
+            metadata(module.meta_data_emit())
         {}
 
         mutable clrie::method_info method;
+        mutable clrie::module_info module;
+        const ModuleID module_id;
         mutable com::ptr<IMetaDataEmit> metadata;
 
         template <class F>
         instruction_sequence make_call(F f) const {
             return make_call_sig(reinterpret_cast<void *>(f), gsl::make_span(func_traits<F>::signature));
         }
+
+        instruction create_call_to_string() const;
 
     protected:
         instruction_sequence make_call_sig(void *fn, gsl::span<const COR_SIGNATURE> signature) const;

--- a/source/method.cpp
+++ b/source/method.cpp
@@ -16,8 +16,9 @@ void appmap::instrumentation_method::initialize(com::ptr<IProfilerManager> manag
 
 void appmap::instrumentation_method::on_module_loaded(clrie::module_info module)
 {
-    spdlog::trace("on_module_loaded({})", module.module_name());
-    modules.insert(module.module_name());
+    const auto name = module.module_name();
+    spdlog::debug("on_module_loaded({})", name);
+    modules.insert(name);
 }
 
 void appmap::instrumentation_method::on_shutdown()
@@ -55,6 +56,7 @@ void appmap::instrumentation_method::instrument_method(clrie::method_info method
         return;
 
     recorder::instrument(method);
+    spdlog::trace("instrument_method({}, {}) finished", method.full_name(), is_rejit);
 }
 
 // This creates a test registry so that a build with tests enabled

--- a/source/method_info.h
+++ b/source/method_info.h
@@ -12,6 +12,7 @@ namespace appmap {
         std::string defined_class;
         std::string method_id;
         bool is_static;
+        std::string return_type;
     };
 
     inline std::unordered_map<FunctionID, method_info> method_infos;

--- a/source/recorder.cpp
+++ b/source/recorder.cpp
@@ -1,3 +1,4 @@
+#include <range/v3/algorithm/move.hpp>
 #include <spdlog/spdlog.h>
 
 #include "recorder.h"
@@ -18,10 +19,44 @@ namespace {
         recorder::events.push_back({event_kind::call, id});
     }
 
-    void method_returned(FunctionID id, [[maybe_unused]] bool is_tail)
+    void method_returned_void(FunctionID id)
     {
         std::lock_guard lock(appmap::recorder::mutex);
         recorder::events.push_back({event_kind::ret, id});
+    }
+
+    template <typename T>
+    void method_returned(T return_value, FunctionID id)
+    {
+        std::lock_guard lock(appmap::recorder::mutex);
+        recorder::events.push_back({event_kind::ret, id, return_value});
+    }
+
+    clrie::instruction_factory::instruction_sequence make_return(const instrumentation &instr, com::ptr<IType> return_type)
+    {
+        switch (return_type.get<CorElementType>(&IType::GetCorElementType)) {
+            case ELEMENT_TYPE_VOID:
+                return instr.make_call(method_returned_void);
+
+            case ELEMENT_TYPE_I1:
+            case ELEMENT_TYPE_I2:
+            case ELEMENT_TYPE_I4:
+            case ELEMENT_TYPE_I8:
+                return instr.make_call(method_returned<int64_t>);
+
+            case ELEMENT_TYPE_BOOLEAN:
+                return instr.make_call(method_returned<bool>);
+
+            default:
+                spdlog::warn("capturing values of type {} unimplemented", std::string(return_type.get(&IType::GetName)));
+                [[fallthrough]];
+
+            case ELEMENT_TYPE_U1:
+            case ELEMENT_TYPE_U2:
+            case ELEMENT_TYPE_U4:
+            case ELEMENT_TYPE_U8:
+                return instr.make_call(method_returned<uint64_t>);
+        }
     }
 
     bool is_tail(com::ptr<IInstruction> inst) {
@@ -37,20 +72,26 @@ namespace {
 void recorder::instrument(clrie::method_info method)
 {
     clrie::instruction_graph code = method.instructions();
-    auto factory = method.instruction_factory();
-    const instrumentation instr{factory, method.module_info().meta_data_emit().as<IMetaDataEmit>()};
+    const instrumentation instr(method);
 
     FunctionID id = method.function_id();
-    method_infos[id] = { method.declaring_type().get(&IType::GetName), method.name(), (method.is_static() || method.is_static_constructor()) };
+    auto return_type = method.return_type();
+    method_infos[id] = {
+        method.declaring_type().get(&IType::GetName),
+        method.name(),
+        (method.is_static() || method.is_static_constructor()),
+        return_type.get(&IType::GetName)
+    };
 
     // prologue
     const auto first = code.first_instruction();
-    code.insert_before(first, factory.load_constants(id));
+    code.insert_before(first, instr.load_constants(id));
     code.insert_before(first, instr.make_call(&method_called));
 
     auto srdi = method.single_ret_default_instrumentation();
     srdi->Initialize(code);
     com::hresult::check(srdi->ApplySingleRetDefaultInstrumentation());
+
     // epilogue
     auto last = code.last_instruction();
     bool tail = is_tail(last);
@@ -58,6 +99,15 @@ void recorder::instrument(clrie::method_info method)
         spdlog::warn("Tail call detected in {} -- tail calls aren't fully supported yet, so your appmap might be incorrect.\n\tPlease report at https://github.com/applandinc/appmap-dotnet/issues", method.full_name());
         last = last.get(&IInstruction::GetPreviousInstruction);
     }
-    code.insert_before_and_retarget_offsets(last, factory.load_constants(id, tail));
-    code.insert_before(last, instr.make_call(&method_returned));
+
+    clrie::instruction_factory::instruction_sequence epilogue;
+
+    if (return_type.get<CorElementType>(&IType::GetCorElementType) != ELEMENT_TYPE_VOID) {
+        epilogue += instr.create_instruction(Cee_Dup);
+    }
+
+    epilogue += instr.load_constants(id);
+    epilogue += make_return(instr, return_type);
+
+    code.insert_before_and_retarget_offsets(last, epilogue);
 }

--- a/source/test_framework.cpp
+++ b/source/test_framework.cpp
@@ -50,13 +50,12 @@ bool appmap::test_framework::instrument(clrie::method_info method)
         return false;
 
     const std::string name = method.full_name();
-    const auto factory = method.instruction_factory();
-    const instrumentation instr{factory, module.meta_data_emit().as<IMetaDataEmit>()};
+    const instrumentation instr(method);
     clrie::instruction_graph code = method.instructions();
     const auto first = code.first_instruction();
 
     if (name == StartCaseName) {
-        code.insert_before(first, factory.create_load_arg_instruction(0));
+        code.insert_before(first, instr.create_load_arg_instruction(0));
         code.insert_before(first, instr.make_call(startCase));
         return true;
     } else if (name == EndCaseName) {


### PR DESCRIPTION
This adds capturing return values; currently integers and strings are captured directly, and all other types are stringified with *System.Object.ToString()*. Fixes #7 .